### PR TITLE
Added a master key option

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -7,26 +7,28 @@
         mc:Ignorable="d"
         DataContext="{StaticResource MainWindowModel}"
         Title="MouseToJoystick" ResizeMode="CanMinimize" SizeToContent="WidthAndHeight">
-  <StackPanel>
-    <Grid>
-      <Label Content="vJoy Device:" HorizontalAlignment="Left" VerticalAlignment="Top" Grid.ColumnSpan="2" Height="26"/>
-      <TextBox x:Name="vJoyDeviceInput" HorizontalAlignment="Left" IsEnabled="{Binding SettingsEnabled}" Text="{Binding DeviceId}" VerticalAlignment="Top" Width="16" Margin="74,4,0,0" Grid.ColumnSpan="2" Height="20"/>
-    </Grid>
     <StackPanel>
-      <CheckBox x:Name="invertXCheckbox" Content="Invert X" Height="15" IsChecked="{Binding InvertX}" IsEnabled="{Binding SettingsEnabled}"/>
-      <CheckBox x:Name="invertYCheckbox" Content="Invert Y" Height="15" IsChecked="{Binding InvertY}" IsEnabled="{Binding SettingsEnabled}"/>
-      <CheckBox Content="Auto-Center" IsChecked="{Binding AutoCenter}" Height="15" IsEnabled="{Binding SettingsEnabled}"/>
-    </StackPanel>
-    <WrapPanel>
-      <Label Content="Screen Size: "/>
-      <RadioButton Content="Automatic" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" Margin="0,0,5,0" IsChecked="{Binding AutoScreenSize}" GroupName="ScreenSize" IsEnabled="{Binding SettingsEnabled}"/>
-      <RadioButton Content="Custom" VerticalContentAlignment="Center" GroupName="ScreenSize" IsChecked="{Binding ManualScreenSize}" IsEnabled="{Binding SettingsEnabled}"/>
-      <Label Content="W:" />
-      <TextBox Width="32" Height="20" IsEnabled="{Binding ManualScreenSize}" Text="{Binding ScreenWidth}"/>
-      <Label Content="H:" />
-      <TextBox Width="32" Height="20" IsEnabled="{Binding ManualScreenSize}" Text="{Binding ScreenHeight}"/>
-    </WrapPanel>
+        <Grid>
+            <Label Content="vJoy Device:" HorizontalAlignment="Left" VerticalAlignment="Top" Grid.ColumnSpan="2" Height="26"/>
+            <TextBox x:Name="vJoyDeviceInput" HorizontalAlignment="Left" IsEnabled="{Binding SettingsEnabled}" Text="{Binding DeviceId}" VerticalAlignment="Top" Width="16" Margin="74,4,0,0" Grid.ColumnSpan="2" Height="20"/>
+            <Label Content="Master: Ctrl +" HorizontalAlignment="Left" Margin="95,0,0,0" VerticalAlignment="Top" Height="26"/>
+            <TextBox x:Name="masterKey" HorizontalAlignment="Left" Margin="177,0,0,0" TextWrapping="Wrap" Text="{Binding MasterKey}" VerticalAlignment="Center" Height="20" Width="48" IsEnabled="{Binding SettingsEnabled}"/>
+        </Grid>
+        <StackPanel>
+            <CheckBox x:Name="invertXCheckbox" Content="Invert X" Height="15" IsChecked="{Binding InvertX}" IsEnabled="{Binding SettingsEnabled}"/>
+            <CheckBox x:Name="invertYCheckbox" Content="Invert Y" Height="15" IsChecked="{Binding InvertY}" IsEnabled="{Binding SettingsEnabled}"/>
+            <CheckBox Content="Auto-Center" IsChecked="{Binding AutoCenter}" Height="15" IsEnabled="{Binding SettingsEnabled}"/>
+        </StackPanel>
+        <WrapPanel>
+            <Label Content="Screen Size: "/>
+            <RadioButton Content="Automatic" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" Margin="0,0,5,0" IsChecked="{Binding AutoScreenSize}" GroupName="ScreenSize" IsEnabled="{Binding SettingsEnabled}"/>
+            <RadioButton Content="Custom" VerticalContentAlignment="Center" GroupName="ScreenSize" IsChecked="{Binding ManualScreenSize}" IsEnabled="{Binding SettingsEnabled}"/>
+            <Label Content="W:" />
+            <TextBox Width="32" Height="20" IsEnabled="{Binding ManualScreenSize}" Text="{Binding ScreenWidth}"/>
+            <Label Content="H:" />
+            <TextBox Width="32" Height="20" IsEnabled="{Binding ManualScreenSize}" Text="{Binding ScreenHeight}"/>
+        </WrapPanel>
     <ToggleButton Content="Run" Click="ToggleButton_Click" IsChecked="{Binding ShouldRun}" Margin="10"></ToggleButton>
     <TextBlock HorizontalAlignment="Right"><Hyperlink FontSize="10" Click="Hyperlink_Click">Open Source Info</Hyperlink></TextBlock>
-  </StackPanel>
+    </StackPanel>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -22,11 +22,12 @@ namespace MouseToJoystick2
             if (model.ShouldRun == true)
             {
                 uint deviceId = Convert.ToUInt32(model.DeviceId);
+                string masterKey = model.MasterKey;
                 int manualWidth = Convert.ToInt32(model.ScreenWidth);
                 int manualHeight = Convert.ToInt32(model.ScreenHeight);
                 try
                 {
-                    handler = new MouseToJoystickHandler(deviceId, model.InvertX, model.InvertY, model.AutoCenter, model.AutoScreenSize, manualWidth, manualHeight);
+                    handler = new MouseToJoystickHandler(masterKey, deviceId, model.InvertX, model.InvertY, model.AutoCenter, model.AutoScreenSize, manualWidth, manualHeight);
                     model.SettingsEnabled = false;
                 }
                 catch (Exception err)

--- a/MainWindowModel.cs
+++ b/MainWindowModel.cs
@@ -6,6 +6,7 @@ namespace MouseToJoystick2
 {
     public class MainWindowModel : INotifyPropertyChanged
     {
+        public string MasterKey { get; set; } = "X";
         public string DeviceId { get; set; } = "1";
         public bool InvertX { get; set; } = false;
         public bool InvertY { get; set; } = false;
@@ -13,7 +14,7 @@ namespace MouseToJoystick2
         public bool AutoScreenSize { get; set; } = true;
         public string ScreenWidth { get; set; } = "640";
         public string ScreenHeight { get; set; } = "480";
-        public bool AutoCenter { get; set; } = true;
+        public bool AutoCenter { get; set; } = false;
         public bool SettingsEnabled { get { return settingsEnabled; } set { settingsEnabled = value; NotifyPropertyChanged(); } }
 
         public event PropertyChangedEventHandler PropertyChanged;


### PR DESCRIPTION
Added a master key option which lets you toggle the feeding on/off while in game. Essential for Flight Simulators. Lets you use mouse yoke like in FSX.

- The mouse position is saved when toggling off and restored when toggling on again. Avoids erratic yoke inputs.
- Changeable master key.

Seems a bit finicky in MSFS 2020. Doesn't register at first press always. Not sure whats going on. Maybe to much input handling going on in the background.